### PR TITLE
feat: add Japanese font support for anime/games section

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,6 +72,11 @@
     font-family: var(--font-love-letter), Arial, Helvetica, sans-serif;
   }
 
+  /* Japanese font support for anime/games section */
+  .japanese-text {
+    font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "Meiryo", "MS Gothic", sans-serif;
+  }
+
   body::-webkit-scrollbar {
     display: none;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Component() {
               <h2 className="text-2xl font-bold mb-4">About Me</h2>
               <div>
                 <h3 className="text-lg font-semibold text-green-400 mb-2">🎮📺 Anime & Games</h3>
-                <ul className="list-disc list-inside text-sm space-y-1">
+                <ul className="list-disc list-inside text-sm space-y-1 japanese-text">
                   <li>Serial Experiments Lain</li>
                   <li>攻殻機動隊</li>
                   <li>イナズマイレブン シリーズ</li>


### PR DESCRIPTION
Fixes #22

Added proper Japanese font support specifically for the anime/games section to improve readability of Japanese titles.

**Changes:**
- Added `.japanese-text` CSS class with Japanese-optimized font stack
- Applied to anime/games list in homepage
- Uses system fonts optimized for CJK characters

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved typography for Japanese text in the Anime & Games section with a dedicated Japanese font stack, delivering clearer rendering of kana/kanji and more consistent appearance across platforms.
  - Applied the new styling via a lightweight utility class; change is purely visual with no impact on functionality or content. Other sections and overall app styling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->