### PR TITLE
feat: add Japanese font support for anime/games section

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,8 @@
 @theme {
   --font-*: initial;
   --font-Love-letter: var(--font-love-letter);
+  --font-Kaisei-decol: var(--font-kaisei-decol);
+  --font-Reggae-one: var(--font-reggae-one);
 
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
@@ -74,7 +76,7 @@
 
   /* Japanese font support for anime/games section */
   .japanese-text {
-    font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "Meiryo", "MS Gothic", sans-serif;
+    font-family: var(--font-kaisei-decol), var(--font-reggae-one), "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "Meiryo", "MS Gothic", sans-serif;
   }
 
   body::-webkit-scrollbar {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { Kaisei_Decol, Reggae_One } from "next/font/google";
 import "./globals.css";
 import { ConditionalBackground } from "@/components/background/ConditionalBackground";
 
@@ -21,6 +22,20 @@ const loveLetter = localFont({
   display: "swap",
 });
 
+const kaiseiDecol = Kaisei_Decol({
+  subsets: ["latin", "latin-ext"],
+  variable: "--font-kaisei-decol",
+  weight: ["400", "500", "700"],
+  display: "swap",
+});
+
+const reggaeOne = Reggae_One({
+  subsets: ["latin", "latin-ext"],
+  variable: "--font-reggae-one",
+  weight: "400",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
   title: "Locus Solus in Wired",
   description: "portfolios of the future",
@@ -34,7 +49,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${loveLetter.variable} ${geistMono.variable} ${geistSans.variable} antialiased`}
+        className={`${loveLetter.variable} ${geistMono.variable} ${geistSans.variable} ${kaiseiDecol.variable} ${reggaeOne.variable} antialiased`}
       >
         <ConditionalBackground />
         {children}


### PR DESCRIPTION
Add Kaisei Decol and Reggae One Google Fonts specifically for the anime/games section. Implemented using Next.js font optimization for better performance.

Closes #39

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced new Japanese fonts (Kaisei Decol, Reggae One) and integrated them into the global font stack to enhance readability and visual appeal for Japanese text.
  * Improved font fallback and loading behavior across the app, providing more consistent typography and reducing flashes of unstyled text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->