### PR TITLE
fix: reorder imports in layout.tsx to satisfy Biome linter

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
 import { Kaisei_Decol, Reggae_One } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 import { ConditionalBackground } from "@/components/background/ConditionalBackground";
 


### PR DESCRIPTION
Fixes #42

Fixed the Biome linter error by reordering import statements in `./src/app/layout.tsx`. The Google fonts import now comes before the local font import as required by the linter rules.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered font imports to standardize module organization and improve readability. No functional impact.

* **Chores**
  * Minor code hygiene update to keep import ordering consistent across the app.

* **No User-Facing Changes**
  * App appearance, layout, and performance remain unchanged. No action required for users or administrators. This update helps maintain consistency and prepares the codebase for future maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->